### PR TITLE
[develop] Update nco version (#1077)

### DIFF
--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -26,7 +26,7 @@ load(pathJoin("cmake", cmake_ver))
 load("srw_common")
 
 load(pathJoin("nccmp", os.getenv("nccmp_ver") or "1.9.0.1"))
-load(pathJoin("nco", os.getenv("nco_ver") or "4.9.3"))
+load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
 load(pathJoin("prod_util", os.getenv("prod_util_ver") or "1.2.2"))
 
 setenv("CMAKE_C_COMPILER","mpiicc")


### PR DESCRIPTION
Hera with Intel compiler was using system installed nco library (4.9.3 version). It was not noticed until sys admins removed read permissions to 4.9.3 version and installed new version (5.1.6).

Will use spack-stack installed nco (version 5.0.6), like all other machines/compilers.
